### PR TITLE
Psi4 fixes

### DIFF
--- a/src/PSI4.cpp
+++ b/src/PSI4.cpp
@@ -126,7 +126,7 @@ double PSI4Energy(vector<QMMMAtom>& QMMMData, QMMMSettings& QMMMOpts, int bead)
     call << "'./LICHM_" << bead << ".180']";
   }
   call << ",return_wfn=True)" << '\n';
-  call << "print('Energy: '+`Eqm`)" << '\n';
+  call << "print('Energy: ', Eqm)" << '\n';
   if (QMMM)
   {
     call << "oeprop(qmwfn,'MULLIKEN_CHARGES')" << '\n';
@@ -676,4 +676,3 @@ double PSI4Opt(vector<QMMMAtom>& QMMMData,
   E *= har2eV;
   return E;
 };
-

--- a/src/PSI4.cpp
+++ b/src/PSI4.cpp
@@ -50,7 +50,7 @@ void PSI4Charges(vector<QMMMAtom>& QMMMData, QMMMSettings& QMMMOpts, int bead)
   WritePSI4Input(QMMMData,call.str(),QMMMOpts,bead);
   //Call PSI4
   call.str("");
-  call << "psi4 -n " << Ncpus << "-i ";
+  call << "psi4 -n " << Ncpus << " -i ";
   call << "LICHM_" << bead << ".dat -o ";
   call << "LICHM_" << bead << ".out > ";
   call << "LICHM_" << bead << ".log";

--- a/src/PSI4.cpp
+++ b/src/PSI4.cpp
@@ -134,7 +134,7 @@ double PSI4Energy(vector<QMMMAtom>& QMMMData, QMMMSettings& QMMMOpts, int bead)
   WritePSI4Input(QMMMData,call.str(),QMMMOpts,bead);
   //Call PSI4
   call.str("");
-  call << "psi4 -n " << Ncpus << "-i ";
+  call << "psi4 -n " << Ncpus << " -i ";
   call << "LICHM_" << bead << ".dat -o ";
   call << "LICHM_" << bead << ".out > ";
   call << "LICHM_" << bead << ".log";
@@ -275,7 +275,7 @@ double PSI4Forces(vector<QMMMAtom>& QMMMData, VectorXd& forces,
   WritePSI4Input(QMMMData,call.str(),QMMMOpts,bead);
   //Call PSI4
   call.str("");
-  call << "psi4 -n " << Ncpus << "-i ";
+  call << "psi4 -n " << Ncpus << " -i ";
   call << "LICHM_" << bead << ".dat -o ";
   call << "LICHM_" << bead << ".out > ";
   call << "LICHM_" << bead << ".log";
@@ -422,7 +422,7 @@ MatrixXd PSI4Hessian(vector<QMMMAtom>& QMMMData, QMMMSettings& QMMMOpts,
   WritePSI4Input(QMMMData,call.str(),QMMMOpts,bead);
   //Call PSI4
   call.str("");
-  call << "psi4 -n " << Ncpus << "-i ";
+  call << "psi4 -n " << Ncpus << " -i ";
   call << "LICHM_" << bead << ".dat -o ";
   call << "LICHM_" << bead << ".out > ";
   call << "LICHM_" << bead << ".log";
@@ -540,7 +540,7 @@ double PSI4Opt(vector<QMMMAtom>& QMMMData,
   WritePSI4Input(QMMMData,call.str(),QMMMOpts,bead);
   //Call PSI4
   call.str("");
-  call << "psi4 -n " << Ncpus << "-i ";
+  call << "psi4 -n " << Ncpus << " -i ";
   call << "LICHM_" << bead << ".dat -o ";
   call << "LICHM_" << bead << ".out > ";
   call << "LICHM_" << bead << ".log";


### PR DESCRIPTION
The original code in `src/PSI4.cpp` has a a few issues with calling Psi4.
  - ``print('Energy: '+ `Eqm`)`` is a syntax error at least in Psi4 1.3.2
  - The system call passes something like `psi4 -n ${Ncpus}-i ${Inputfile}` to the shell. The missing space causes another call error

Both issues are fixed in this simple PR and i have successfully done calculations with Psi4 and those fixes.