### PR TITLE
Use NProcShared for Gaussian processor directive

### DIFF
--- a/src/Struct_writer.cpp
+++ b/src/Struct_writer.cpp
@@ -76,12 +76,7 @@ void WriteGauInput(vector<QMMMAtom>& QMMMData, string calcTyp,
   }
   call << '\n';
   //Start: Hatice
-  if(g09){
-    call << "%NprocShared=" << Ncpus << '\n';
-  }
-  else{
-    call << "%CPU=0-" << Ncpus-1 << '\n';
-  }
+  call << "%NProcShared=" << Ncpus << '\n';
   //End: Hatice
   //Add ROUTE section
   call << calcTyp;


### PR DESCRIPTION
Replaced the Gaussian %CPU directive with %NProcShared in Struct_writer.cpp to avoid MP_BLIST/CPU binding issues on HPC systems.